### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden entrypoint.sh against shell injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-18 - Shell Script Injection via Globbing
+
+**Vulnerability:** Unquoted variable expansion in `entrypoint.sh` used for splitting command strings into arguments also enabled shell globbing (wildcard expansion). If an input contained `*`, it would expand to filenames in the current directory.
+**Learning:** Shell scripts often need to split strings into arguments, but unquoted expansion (`$VAR`) does both splitting and globbing. This is a common but subtle vulnerability when handling user input in entrypoint scripts.
+**Prevention:** When unquoted expansion is required for argument splitting, wrap the code block in `set -f` (disable globbing) and `set +f`. Ideally, use arrays (`"${arr[@]}"`) which handle arguments safely without splitting or globbing, but this requires the input to be parsed into an array first.

--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -25,7 +25,7 @@ set -e
 
 CONFIG=/var/lib/softether/vpn_server.config
 
-if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
+if [ ! -f "$CONFIG" ] || [ ! -s "$CONFIG" ]; then
   # Generate a random PSK if not provided
   : ${PSK:=$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | fold -w 20 | head -n 1)}
 
@@ -140,9 +140,9 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   if [[ $USERS ]]; then
     while IFS=';' read -ra USER; do
       for i in "${USER[@]}"; do
-        IFS=':' read username password <<<"$i"
+        IFS=':' read -r username password <<<"$i"
         # echo "Creating user: ${username}"
-        adduser $username $password
+        adduser "$username" "$password"
       done
     done <<<"$USERS"
   else
@@ -156,15 +156,19 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
 
   # handle VPNCMD_* commands right before setting admin passwords
   if [[ $VPNCMD_SERVER ]]; then
+    set -f
     while IFS=";" read -ra CMD; do
       vpncmd_server $CMD
     done <<<"$VPNCMD_SERVER"
+    set +f
   fi
 
   if [[ $VPNCMD_HUB ]]; then
+    set -f
     while IFS=";" read -ra CMD; do
       vpncmd_hub $CMD
     done <<<"$VPNCMD_HUB"
+    set +f
   fi
 
   # set password for hub

--- a/copyables/gencert.sh
+++ b/copyables/gencert.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-/usr/bin/vpnserver start 2>&1 >/dev/null
+/usr/local/bin/vpnserver start 2>&1 >/dev/null
 
 # while-loop to wait until server comes up
 # switch cipher
 while :; do
     set +e
-    /usr/bin/vpncmd localhost /SERVER /CSV /CMD OpenVpnEnable yes /PORTS:1194 2>&1 >/dev/null
+    /usr/local/bin/vpncmd localhost /SERVER /CSV /CMD OpenVpnEnable yes /PORTS:1194 2>&1 >/dev/null
     [[ $? -eq 0 ]] && break
     set -e
     sleep 1
 done
 
-/usr/bin/vpncmd localhost /SERVER /CSV /CMD ServerCertGet cert
-/usr/bin/vpncmd localhost /SERVER /CSV /CMD ServerKeyGet key
+/usr/local/bin/vpncmd localhost /SERVER /CSV /CMD ServerCertGet cert
+/usr/local/bin/vpncmd localhost /SERVER /CSV /CMD ServerKeyGet key
 
 CERT=$(cat cert | sed -r 's/\-{5}[^\-]+\-{5}//g;s/[^A-Za-z0-9\+\/\=]//g;' | tr -d '\r\n')
 KEY=$(cat key | sed -r 's/\-{5}[^\-]+\-{5}//g;s/[^A-Za-z0-9\+\/\=]//g;' | tr -d '\r\n')


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Harden entrypoint.sh against shell injection

🚨 Severity: MEDIUM
💡 Vulnerability: Unquoted variable expansion in command processing loops allowed shell globbing (wildcard expansion), potentially leading to unintended file processing or execution if input contained characters like `*`.
🎯 Impact: Could be exploited to reference unexpected files or cause denial of service via malformed environment variables.
🔧 Fix: Hardened `entrypoint.sh` by:
  - Quoting variables (`$CONFIG`, `$username`, `$password`) to prevent word splitting.
  - Using `read -r` to prevent backslash interpretation.
  - Using `set -f` (noglob) around command execution loops to prevent wildcard expansion while allowing argument splitting.
  - Fixed broken paths in `gencert.sh` pointing to `/usr/bin` instead of `/usr/local/bin`.
✅ Verification: Verified script syntax with `bash -n`.

---
*PR created automatically by Jules for task [6480463339127224038](https://jules.google.com/task/6480463339127224038) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation and argument handling in shell scripts to prevent unintended expansions and word-splitting issues.
  * Updated system binary paths for compatibility with installation location changes.

* **Documentation**
  * Added security documentation covering shell script expansion handling best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->