### PR TITLE
🛡️ Sentinel: Fix shell scripting vulnerabilities in entrypoint.sh

### DIFF
--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -37,13 +37,13 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
     echo '# <use the password specified at -e USERS>'
   else
     : ${USERNAME:=user$(cat /dev/urandom | tr -dc '0-9' | fold -w 4 | head -n 1)}
-    echo \# ${USERNAME}
+    echo "# ${USERNAME}"
 
     if [[ $PASSWORD ]]; then
       echo '# <use the password specified at -e PASSWORD>'
     else
       PASSWORD=$(cat /dev/urandom | tr -dc '0-9' | fold -w 20 | head -n 1 | sed 's/.\{4\}/&./g;s/.$//;')
-      echo \# ${PASSWORD}
+      echo "# ${PASSWORD}"
     fi
   fi
 
@@ -130,7 +130,7 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   # add user
 
   adduser() {
-    printf " $1"
+    printf " %s" "$1"
     vpncmd_hub UserCreate "$1" /GROUP:none /REALNAME:none /NOTE:none
     vpncmd_hub UserPasswordSet "$1" /PASSWORD:"$2"
   }
@@ -140,13 +140,13 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   if [[ $USERS ]]; then
     while IFS=';' read -ra USER; do
       for i in "${USER[@]}"; do
-        IFS=':' read username password <<<"$i"
+        IFS=':' read -r username password <<<"$i"
         # echo "Creating user: ${username}"
-        adduser $username $password
+        adduser "$username" "$password"
       done
     done <<<"$USERS"
   else
-    adduser $USERNAME $PASSWORD
+    adduser "$USERNAME" "$PASSWORD"
   fi
 
   echo


### PR DESCRIPTION
Hardened `copyables/entrypoint.sh` against several shell scripting vulnerabilities:
1.  **Format String Injection**: Changed `printf " $1"` to `printf " %s" "$1"` in `adduser` function.
2.  **Globbing/Word Splitting**: Quoted `$username` and `$password` variables in `adduser` calls. This prevents passwords containing `*` or spaces from being mishandled.
3.  **Input Integrity**: Added `-r` flag to `read` command to prevent backslashes from being interpreted as escape characters.
4.  **Information Leak/Globbing**: Quoted variables in `echo` statements to prevent accidental globbing of sensitive values.

---
*PR created automatically by Jules for task [2210651823306672991](https://jules.google.com/task/2210651823306672991) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stability and reliability of the user creation process through enhanced script robustness and better handling of input data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->