### PR TITLE
🛡️ Sentinel: Fix injection risks and logic bugs in entrypoint.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-02 - Unquoted Variable Expansion in Entrypoint Scripts
+**Vulnerability:** Command injection and argument hijacking via unquoted variables in shell scripts.
+**Learning:** Shell variables passed to functions or commands without quotes are subject to word splitting and globbing. In `entrypoint.sh`, `adduser $username $password` allowed a password containing globs (e.g., `*`) to expand to filenames, or spaces to shift arguments.
+**Prevention:** Always quote variable expansions (`"$var"`). For dynamic commands where word splitting is desired but globbing is not, use `set -f` before execution and `set +f` after.


### PR DESCRIPTION
🛡️ Sentinel Security Fixes

**Severity:** HIGH

**Vulnerability:**
1.  **Argument Injection/Globbing:** Unquoted variables in `adduser` and `VPNCMD_*` execution allowed shell globbing. A password like `*` could expand to filenames, leaking information or causing unexpected behavior.
2.  **Logic Bug:** The loop processing `VPNCMD_SERVER` and `VPNCMD_HUB` was broken. It only executed the first command in the list, ignoring subsequent commands.
3.  **Format String:** `printf " $1"` is theoretically vulnerable to format string attacks if `$1` contains `%`.

**Fix:**
1.  Quoted all variable expansions in `adduser`.
2.  Refactored `VPNCMD_*` loops to correctly split by semicolon and iterate.
3.  Used `set -f` (disable globbing) + `set +f` around dynamic command execution to allow word splitting (for arguments) but prevent wildcard expansion.
4.  Used `printf " %s" "$1"` for safe printing.
5.  Added `read -r` to preserve backslashes in inputs.

**Verification:**
Verified with a test script simulating `adduser` calls and `VPNCMD` loop processing, confirming correct argument handling and glob prevention. Ran `bash -n` to verify syntax.

---
*PR created automatically by Jules for task [1117922649488346055](https://jules.google.com/task/1117922649488346055) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Fixed shell variable expansion vulnerability that could lead to command injection and argument hijacking in entrypoint configuration.
  * Improved handling of user credentials and VPN commands with proper input validation and special character processing.
  * Enhanced robustness to prevent word-splitting and misinterpretation of configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->