### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection and weak password risks in entrypoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Shell Variable Expansion and Word Splitting
+**Vulnerability:** Unquoted variable expansions in shell scripts (`copyables/entrypoint.sh`), specifically `adduser $username $password`, allowed argument injection (splitting passwords with spaces) and globbing (passwords matching filenames).
+**Learning:** Shell scripts are vulnerable to word splitting and globbing when variables are not quoted. This can lead to security misconfigurations (weak passwords) or unexpected behavior.
+**Prevention:** Always quote variable expansions (`"$var"`) unless word splitting is explicitly intended. Use `read -r` to prevent backslash interpretation. Use `printf " %s" "$var"` to prevent format string injection.


### PR DESCRIPTION
This PR addresses critical shell scripting vulnerabilities in `copyables/entrypoint.sh`.

**Vulnerabilities Fixed:**
1.  **Argument Injection/Word Splitting:** Passwords containing spaces were being split into multiple arguments, causing `adduser` to set truncated passwords. This significantly weakened security for users attempting to set passphrases.
2.  **Globbing:** Unquoted variables could expand to filenames if they contained glob characters (e.g., `*`), potentially setting predictable passwords based on directory contents.
3.  **Format String Injection:** `printf " $1"` was changed to `printf " %s" "$1"` to safely handle usernames containing formatting characters.
4.  **Backslash Interpretation:** Added `read -r` to ensure backslashes in credentials are treated literally.

**Verification:**
- Verified logic using a mock script `verify_security_fix.sh` which confirmed that spaces and glob characters are now preserved.
- Validated syntax with `bash -n copyables/entrypoint.sh`.


---
*PR created automatically by Jules for task [3146024203369766883](https://jules.google.com/task/3146024203369766883) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security of shell script processing to prevent injection and argument expansion vulnerabilities
  * Improved handling of special characters in credentials and configuration parameters

* **Documentation**
  * Added security best practices guide documenting shell variable expansion vulnerabilities and mitigation strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->