### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix shell script quoting and globbing vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+## 2025-02-18 - Shell Script Variable Quoting and Globbing
+**Vulnerability:** Unquoted variables in shell scripts (specifically `entrypoint.sh`) caused data loss (truncated passwords) and introduced globbing vulnerabilities (expanding `*` to filenames in dynamic commands).
+**Learning:** Shell scripts processing complex environment variables (like semicolon-separated lists of commands or credentials) are highly prone to parsing errors if variable expansion is not strictly controlled. Standard `read` interprets backslashes, and unquoted variable expansion triggers word splitting and globbing.
+**Prevention:**
+1. Always use `read -r` to prevent backslash interpretation.
+2. Always quote variables (`"$var"`) to prevent word splitting, unless splitting is explicitly intended.
+3. If word splitting is intended (e.g., parsing a command string), wrap the execution in `set -f; ...; set +f` to prevent unintended globbing.
+4. Use `printf " %s" "$var"` instead of `printf " $var"` to avoid format string injection.


### PR DESCRIPTION
This PR addresses multiple shell scripting vulnerabilities in `copyables/entrypoint.sh`. It enforces strict variable quoting, disables backslash interpretation in `read`, prevents format string injection, and safely handles dynamic command execution by disabling globbing. This ensures robust handling of user credentials and configuration commands.

---
*PR created automatically by Jules for task [209830914703777865](https://jules.google.com/task/209830914703777865) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened shell script security by improving variable quoting and input parsing to prevent unintended word-splitting, data loss, and potential injection vulnerabilities.

* **Documentation**
  * Added security documentation detailing best practices for variable quoting, safe input parsing, and globbing protection to prevent common shell scripting vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->