### PR TITLE
🛡️ Sentinel: Fix shell injection and parsing vulnerabilities in entrypoint.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+## 2024-11-26 - Shell Script Injection Patterns
+**Vulnerability:** Widespread unquoted variables and unsafe `read` usage in `entrypoint.sh` allowed for argument injection (word splitting), file enumeration (globbing), and data corruption (backslash stripping).
+**Learning:** The codebase used `while read` loops on variables containing semicolons without properly handling array iteration or disabling globbing, leading to both functional bugs (ignoring subsequent commands) and security risks.
+**Prevention:**
+1. Always quote variable expansions: `"$VAR"`.
+2. Use `read -r` to disable backslash escaping.
+3. To safely split strings into arguments without globbing: `set -f; command $args; set +f`.
+4. Use `printf " %s" "$var"` instead of `printf " $var"` to prevent format string attacks.


### PR DESCRIPTION
This PR hardens the `copyables/entrypoint.sh` script by fixing several shell scripting vulnerabilities.

**Security Fixes:**
1.  **Variable Quoting:** Added double quotes around variables (e.g., `"$PSK"`, `"$USERNAME"`) to prevent accidental word splitting and file globbing.
2.  **Password Safety:** Switched to `read -r` to prevent backslashes in passwords/usernames from being interpreted as escape characters.
3.  **Globbing Prevention:** Implemented `set -f` (noglob) when processing dynamic commands from `VPNCMD_SERVER` and `VPNCMD_HUB` to safely split arguments without expanding wildcards.
4.  **Format String Protection:** Changed `printf " $1"` to `printf " %s" "$1"` in the `adduser` function.

**Bug Fixes:**
- Fixed the loop logic for `VPNCMD_SERVER` and `VPNCMD_HUB` to correctly iterate over all semicolon-separated commands (previously only the first command was executed).

**Verification:**
A verification script was created and run to confirm:
- Passwords with spaces are preserved.
- `*` in passwords does not expand to filenames.
- Backslashes in passwords are preserved.
- Multiple commands in environment variables are executed sequentially.

---
*PR created automatically by Jules for task [12604410747989356806](https://jules.google.com/task/12604410747989356806) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security guidance covering shell script injection patterns and mitigation strategies.

* **Bug Fixes**
  * Improved robustness of script handling for special characters and spaces in inputs.
  * Enhanced input parsing and variable quoting to prevent injection vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->