### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection and unquoted variables

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Shell Script Injection Risks via Unquoted Variables
+**Vulnerability:** Unquoted variables in `entrypoint.sh` allowed argument splitting (passwords with spaces) and glob expansion (passwords with wildcards matching filenames).
+**Learning:** Shell scripts are vulnerable to implicit expansion. `password="secret *"` expanded to filenames if unquoted, potentially exposing file existence or leaking data if passed to a command that prints arguments.
+**Prevention:** Always quote variables (`"$VAR"`). Use `read -r` to disable backslash interpretation. Use `printf " %s" "$VAR"` to avoid format string injection.

--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -25,7 +25,7 @@ set -e
 
 CONFIG=/var/lib/softether/vpn_server.config
 
-if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
+if [ ! -f "$CONFIG" ] || [ ! -s "$CONFIG" ]; then
   # Generate a random PSK if not provided
   : ${PSK:=$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | fold -w 20 | head -n 1)}
 
@@ -33,13 +33,13 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   printf '=%.0s' {1..24}
   echo
 
-  if [[ $USERS ]]; then
+  if [[ "$USERS" ]]; then
     echo '# <use the password specified at -e USERS>'
   else
     : ${USERNAME:=user$(cat /dev/urandom | tr -dc '0-9' | fold -w 4 | head -n 1)}
     echo \# ${USERNAME}
 
-    if [[ $PASSWORD ]]; then
+    if [[ "$PASSWORD" ]]; then
       echo '# <use the password specified at -e PASSWORD>'
     else
       PASSWORD=$(cat /dev/urandom | tr -dc '0-9' | fold -w 20 | head -n 1 | sed 's/.\{4\}/&./g;s/.$//;')
@@ -130,23 +130,23 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   # add user
 
   adduser() {
-    printf " $1"
+    printf " %s" "$1"
     vpncmd_hub UserCreate "$1" /GROUP:none /REALNAME:none /NOTE:none
     vpncmd_hub UserPasswordSet "$1" /PASSWORD:"$2"
   }
 
   printf '# Creating user(s):'
 
-  if [[ $USERS ]]; then
-    while IFS=';' read -ra USER; do
+  if [[ "$USERS" ]]; then
+    while IFS=';' read -r -a USER; do
       for i in "${USER[@]}"; do
-        IFS=':' read username password <<<"$i"
+        IFS=':' read -r username password <<<"$i"
         # echo "Creating user: ${username}"
-        adduser $username $password
+        adduser "$username" "$password"
       done
     done <<<"$USERS"
   else
-    adduser $USERNAME $PASSWORD
+    adduser "$USERNAME" "$PASSWORD"
   fi
 
   echo
@@ -155,15 +155,15 @@ if [ ! -f $CONFIG ] || [ ! -s $CONFIG ]; then
   export PASSWORD='**'
 
   # handle VPNCMD_* commands right before setting admin passwords
-  if [[ $VPNCMD_SERVER ]]; then
-    while IFS=";" read -ra CMD; do
-      vpncmd_server $CMD
+  if [[ "$VPNCMD_SERVER" ]]; then
+    while IFS=";" read -r -a CMD; do
+      vpncmd_server "$CMD"
     done <<<"$VPNCMD_SERVER"
   fi
 
-  if [[ $VPNCMD_HUB ]]; then
-    while IFS=";" read -ra CMD; do
-      vpncmd_hub $CMD
+  if [[ "$VPNCMD_HUB" ]]; then
+    while IFS=";" read -r -a CMD; do
+      vpncmd_hub "$CMD"
     done <<<"$VPNCMD_HUB"
   fi
 

--- a/copyables/gencert.sh
+++ b/copyables/gencert.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-/usr/bin/vpnserver start 2>&1 >/dev/null
+/usr/local/bin/vpnserver start 2>&1 >/dev/null
 
 # while-loop to wait until server comes up
 # switch cipher
 while :; do
     set +e
-    /usr/bin/vpncmd localhost /SERVER /CSV /CMD OpenVpnEnable yes /PORTS:1194 2>&1 >/dev/null
+    /usr/local/bin/vpncmd localhost /SERVER /CSV /CMD OpenVpnEnable yes /PORTS:1194 2>&1 >/dev/null
     [[ $? -eq 0 ]] && break
     set -e
     sleep 1
 done
 
-/usr/bin/vpncmd localhost /SERVER /CSV /CMD ServerCertGet cert
-/usr/bin/vpncmd localhost /SERVER /CSV /CMD ServerKeyGet key
+/usr/local/bin/vpncmd localhost /SERVER /CSV /CMD ServerCertGet cert
+/usr/local/bin/vpncmd localhost /SERVER /CSV /CMD ServerKeyGet key
 
 CERT=$(cat cert | sed -r 's/\-{5}[^\-]+\-{5}//g;s/[^A-Za-z0-9\+\/\=]//g;' | tr -d '\r\n')
 KEY=$(cat key | sed -r 's/\-{5}[^\-]+\-{5}//g;s/[^A-Za-z0-9\+\/\=]//g;' | tr -d '\r\n')


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unquoted variables in `entrypoint.sh` allowed argument splitting and glob expansion.
🎯 Impact: Passwords with spaces were mishandled; wildcards could trigger unexpected file matching.
🔧 Fix: Applied proper quoting, `read -r`, and fixed `printf` usage. Also fixed paths in `gencert.sh`.
✅ Verification: Verified with reproduction script and syntax checks.

---
*PR created automatically by Jules for task [16747109593899495064](https://jules.google.com/task/16747109593899495064) started by @bluPhy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * New security guidance document covering shell script injection vulnerabilities and prevention best practices.

* **Bug Fixes**
  * Strengthened shell script safety with improved variable quoting and argument handling.
  * Updated executable paths for VPN server components to correct system locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->