### PR TITLE
ci: remove Azure ACR login and push; only push to Docker Hub

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,7 +22,6 @@ jobs:
         shell: bash
     env:
       TAG_HUB: "ajleal/softether:latest"
-      TAG_ACR: "prodmycorpone.azurecr.io/softether:latest"
       PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
       WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
       WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
@@ -47,13 +46,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Login to Azure ACR
-        uses: docker/login-action@v3
-        with:
-          registry: prodmycorpone.azurecr.io
-          username: ${{ secrets.ACR_PRODMYCORPONE_USER }}
-          password: ${{ secrets.ACR_PRODMYCORPONE_PASSWORD }}
-
       - name: Build (Pre-Scan)
         # Build for all platforms to ensure it works and populate cache.
         # Not pushing yet.
@@ -63,7 +55,6 @@ jobs:
             --provenance=true \
             --platform $PLATFORMS \
             --tag $TAG_HUB \
-            --tag $TAG_ACR \
             .
 
       - name: Install Wiz CLI
@@ -89,7 +80,7 @@ jobs:
             --image "$TAG_HUB" \
             --policy "Default vulnerabilities policy"
 
-      - name: Push to Registries
+      - name: Push to Docker Hub
         if: success()
         run: |
           docker buildx build \
@@ -98,5 +89,4 @@ jobs:
             --provenance=true \
             --platform $PLATFORMS \
             --tag $TAG_HUB \
-            --tag $TAG_ACR \
             .


### PR DESCRIPTION
### Motivation
- Stop publishing the built image to Azure ACR and remove use of ACR-related secrets and login steps so the workflow only builds, scans, and pushes to Docker Hub.

### Description
- Updated `.github/workflows/image.yml` to remove the `TAG_ACR` environment variable, drop the Azure ACR `docker/login-action@v3` step, remove ACR tags from `docker buildx build` invocations, and rename the final step to `Push to Docker Hub` so only `TAG_HUB` is pushed.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07df7f85c8326a6a990104aa712c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the container image publishing pipeline to focus exclusively on Docker Hub distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->