### PR TITLE
Load pre-scan image into Docker daemon so Wiz Docker scan can find it

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -47,13 +47,13 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build (Pre-Scan)
-        # Build for all platforms to ensure it works and populate cache.
-        # Not pushing yet.
+        # Build a single-arch local image so Wiz can scan it via Docker daemon.
         run: |
           docker buildx build \
+            --load \
             --sbom=true \
             --provenance=true \
-            --platform $PLATFORMS \
+            --platform linux/amd64 \
             --tag $TAG_HUB \
             .
 


### PR DESCRIPTION
### Motivation
- The Wiz Docker scan failed with `No such image` because the pre-scan `docker buildx` output was not loaded into the local Docker daemon. 
- The goal is to make the image reference passed to `wizcli docker scan` available locally while keeping the multi-arch push step for releases. 

### Description
- Added `--load` to the pre-scan `docker buildx build` in the `Build (Pre-Scan)` step so the built image is imported into the local Docker daemon. 
- Switched the pre-scan build `--platform` to `linux/amd64` to make `--load` compatible with Buildx. 
- Left the later `Push to Docker Hub` step unchanged so multi-platform `--platform $PLATFORMS` and `--push` remain used for publishing. 

### Testing
- Ran `git diff -- .github/workflows/image.yml` to review the workflow diff and it succeeded. 
- Ran `git diff --check` to validate formatting and it succeeded. 
- Ran `git status --short` to confirm the working tree state and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2383e106083269ee01ec44e697b44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to target single-platform architecture (linux/amd64) for optimized local builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->