### PR TITLE
Fix pre-scan Buildx `--load` manifest-list export failure in image workflow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -48,11 +48,13 @@ jobs:
 
       - name: Build (Pre-Scan)
         # Build a single-arch local image so Wiz can scan it via Docker daemon.
+        # Keep attestations off here because the docker exporter used by --load
+        # cannot export manifest lists with provenance/SBOM enabled.
         run: |
           docker buildx build \
             --load \
-            --sbom=true \
-            --provenance=true \
+            --sbom=false \
+            --provenance=false \
             --platform linux/amd64 \
             --tag $TAG_HUB \
             .


### PR DESCRIPTION
### Motivation
- The GitHub Actions pre-scan step used `docker buildx build --load` with SBOM and provenance enabled which caused `ERROR: failed to build: docker exporter does not currently support exporting manifest lists`.
- The pre-scan needs a single-arch image loaded into the local Docker daemon so Wiz can scan it, and that local `--load` path cannot include attestations/manifest lists.

### Description
- Updated `.github/workflows/image.yml` Build (Pre-Scan) step to set `--sbom=false` and `--provenance=false` for the `--load` build so the docker exporter will not attempt to export manifest lists.
- Added an inline comment explaining why attestations are disabled for the local pre-scan build.
- Left the later multi-platform `docker buildx build --push` step unchanged so SBOM/provenance remain enabled when pushing published images.

### Testing
- Parsed the workflow YAML with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/image.yml'); puts 'ok'"`, which succeeded.
- Attempted to parse with Python using `yaml` but the environment lacks `PyYAML` causing `ModuleNotFoundError`, so that check failed due to missing dependency rather than malformed YAML.
- Inspected the modified file to verify the `--sbom=false` and `--provenance=false` flags are present in the pre-scan step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23deacd9483269ee3d24356193022)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build pipeline configuration to streamline the pre-scan build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->